### PR TITLE
Remove use of realpath since Mac doesn't have it

### DIFF
--- a/{{cookiecutter.package_name}}/bundles/docker/scripts/build_server.sh
+++ b/{{cookiecutter.package_name}}/bundles/docker/scripts/build_server.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 CURRENT_DIR=`dirname "$0"`
-DEPLOY_DIR=`realpath $CURRENT_DIR/..`
-ROOT_DIR=`realpath $CURRENT_DIR/../../..`
+
+# Since Mac doesn't come with realpath by default, let's set the full
+# paths using PWD.
+pushd .
+cd $CURRENT_DIR/..
+DEPLOY_DIR=$PWD
+cd $CURRENT_DIR/../../..
+ROOT_DIR=$PWD
+popd
 
 docker run -it --rm         \
     -e TRAME_BUILD_ONLY=1 \

--- a/{{cookiecutter.package_name}}/bundles/docker/scripts/run_server.sh
+++ b/{{cookiecutter.package_name}}/bundles/docker/scripts/run_server.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 CURRENT_DIR=`dirname "$0"`
-DEPLOY_DIR=`realpath $CURRENT_DIR/..`
+
+# Since Mac doesn't come with realpath by default, let's set the full
+# paths using PWD.
+pushd .
+cd $CURRENT_DIR/..
+DEPLOY_DIR=$PWD
+popd
 
 docker run -it --rm \
     -p 8080:80 \


### PR DESCRIPTION
It *is* available if you `brew install coreutils`, which is certainly
recommended. But not every user will do this, so let's avoid using it.

If we start having to do this kind of thing a lot more, maybe we can
consider making a bash function for it.