### PR TITLE
Add jupyter functions and examples

### DIFF
--- a/{{cookiecutter.package_name}}/examples/jupyter/loop.ipynb
+++ b/{{cookiecutter.package_name}}/examples/jupyter/loop.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2589707",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from {{cookiecutter.import_name}}.app.jupyter import run_in_loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98d42b44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_in_loop(height=600)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/{{cookiecutter.package_name}}/examples/jupyter/proxy.ipynb
+++ b/{{cookiecutter.package_name}}/examples/jupyter/proxy.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2589707",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trame.jupyter import run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3224729a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"{{cookiecutter.entry_point}}\", height=600)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -45,4 +45,6 @@ install_requires =
 [options.entry_points]
 console_scripts =
     {{cookiecutter.entry_point}} = {{cookiecutter.import_name}}:main
+jupyter_serverproxy_servers =
+    {{cookiecutter.entry_point}} = {{cookiecutter.import_name}}.app.jupyter:jupyter_proxy_info
 {%- endif %}

--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/engine.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/engine.py
@@ -1,27 +1,32 @@
 r"""
 Define your classes and create the instances that you need to expose
 """
+import logging
+
 from trame import state
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------
 # Methods
 # ---------------------------------------------------------
 
 def initialize():
-    print(">>> ENGINE: Application initialize only once")
+    logger.info(">>> ENGINE: Application initialize only once")
 
 def protocols_ready():
-    print(">>> ENGINE: Server protocols initialized / Client not connected yet")
+    logger.info(">>> ENGINE: Server protocols initialized / Client not connected yet")
 
 def reset_resolution():
     state.resolution = 6
 
 {%- if cookiecutter.include_components %}
 def widget_click():
-    print(">>> ENGINE: Widget Click")
+    logger.info(">>> ENGINE: Widget Click")
 
 def widget_change():
-    print(">>> ENGINE: Widget Change")
+    logger.info(">>> ENGINE: Widget Change")
 
 {%- endif %}
 
@@ -31,4 +36,4 @@ def widget_change():
 
 @state.change("resolution")
 def resolution_changed(resolution, **kwargs):
-    print(f">>> ENGINE: Slider updating resolution to {resolution}")
+    logger.info(f">>> ENGINE: Slider updating resolution to {resolution}")

--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/jupyter.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/jupyter.py
@@ -1,0 +1,35 @@
+import asyncio
+
+from trame import port
+from trame.jupyter import display_iframe
+
+from {{cookiecutter.import_name}}.app import controller, ui
+
+
+def run_in_loop(**kwargs):
+    """Run and display the trame application in jupyter's event loop
+
+    The kwargs are forwarded to IPython.display.IFrame()
+    """
+    controller.on_start()
+    ui.layout.start(exec_mode="task", server=True)
+
+    def display():
+        src = f"http://localhost:{port()}"
+        display_iframe(src, **kwargs)
+
+    # Give wslink a tiny bit of time to get started
+    loop = asyncio.get_event_loop()
+    loop.call_later(0.1, display)
+
+
+def jupyter_proxy_info():
+    """Get the config to run the trame application via jupyter's server proxy
+
+    This is provided to the `jupyter_serverproxy_servers` entrypoint, and the
+    jupyter server proxy will use it to start the application as a separate
+    process.
+    """
+    return {
+        'command': ['{{cookiecutter.entry_point}}', '-p', '{port}', '--server'],
+    }

--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/jupyter.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/jupyter.py
@@ -6,13 +6,27 @@ from trame.jupyter import display_iframe
 from {{cookiecutter.import_name}}.app import controller, ui
 
 
+# Keep track of whether we have ran this function before
+FIRST_RUN = True
+
+
 def run_in_loop(**kwargs):
     """Run and display the trame application in jupyter's event loop
 
     The kwargs are forwarded to IPython.display.IFrame()
     """
-    controller.on_start()
-    ui.layout.start(exec_mode="task", server=True)
+    global FIRST_RUN
+    if FIRST_RUN:
+        # Disable info logging for the engine logger
+        import logging
+        engine_logger = logging.getLogger("{{cookiecutter.import_name}}.app.engine")
+        engine_logger.setLevel(logging.WARNING)
+
+        # Start up trame
+        controller.on_start()
+        ui.layout.start(exec_mode="task", server=True)
+
+        FIRST_RUN = False
 
     def display():
         src = f"http://localhost:{port()}"


### PR DESCRIPTION
This adds functions and examples for running trame in either a jupyter server proxy process or
within the jupyter event loop.

Depends on: kitware/trame#54