### PR TITLE
fix ruff errors

### DIFF
--- a/{{cookiecutter.package_name}}/src/{{cookiecutter.import_name}}/app/core.py
+++ b/{{cookiecutter.package_name}}/src/{{cookiecutter.import_name}}/app/core.py
@@ -31,22 +31,22 @@ class MyTrameApp(TrameApp):
         self.state.resolution = 6
 
     @change("resolution")
-    def on_resolution_change(self, resolution, **kwargs):
-        print(f">>> ENGINE(a): Slider updating resolution to {resolution}")
+    def on_resolution_change(self, resolution, **_kwargs):
+        print(f">>> ENGINE(a): Slider updating resolution to {resolution}") # noqa : T201
 
 {%- if cookiecutter.include_components %}
 
     @controller.set("widget_click")
     def widget_click(self):
-        print(">>> ENGINE(a): Widget Click")
+        print(">>> ENGINE(a): Widget Click") # noqa : T201
 
     @controller.set("widget_change")
     def widget_change(self):
-        print(">>> ENGINE(a): Widget Change")
+        print(">>> ENGINE(a): Widget Change") # noqa : T201
 
 {%- endif %}
 
-    def _build_ui(self, *args, **kwargs):
+    def _build_ui(self, *_args, **_kwargs):
         with SinglePageLayout(self.server) as self.ui:
             # Toolbar
             self.ui.title.set_text("Trame / vtk.js")


### PR DESCRIPTION
Running a basic cookiecutter from the `update-cookiecutter` branch I had the following pre-commit checks not passing:
```
ARG002 Unused method argument: `kwargs`
  --> src/trame_app/app/core.py:31:50
   |
30 |     @change("resolution")
31 |     def on_resolution_change(self, resolution, **kwargs):
   |                                                  ^^^^^^
32 |         print(f">>> ENGINE(a): Slider updating resolution to {resolution}")
   |

T201 `print` found
  --> src/trame_app/app/core.py:32:9
   |
30 |     @change("resolution")
31 |     def on_resolution_change(self, resolution, **kwargs):
32 |         print(f">>> ENGINE(a): Slider updating resolution to {resolution}")
   |         ^^^^^
33 |
34 |     def _build_ui(self, *args, **kwargs):
   |
help: Remove `print`

ARG002 Unused method argument: `args`
  --> src/trame_app/app/core.py:34:26
   |
32 |         print(f">>> ENGINE(a): Slider updating resolution to {resolution}")
33 |
34 |     def _build_ui(self, *args, **kwargs):
   |                          ^^^^
35 |         with SinglePageLayout(self.server) as self.ui:
36 |             # Toolbar
   |

ARG002 Unused method argument: `kwargs`
  --> src/trame_app/app/core.py:34:34
   |
32 |         print(f">>> ENGINE(a): Slider updating resolution to {resolution}")
33 |
34 |     def _build_ui(self, *args, **kwargs):
   |                                  ^^^^^^
35 |         with SinglePageLayout(self.server) as self.ui:
36 |             # Toolbar
   |
```

This fixes them