### PR TITLE
fix(pre-commit): fix component application creation error

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -12,8 +12,7 @@ def remove_files(*paths):
 
 def remove_dirs(*paths):
     for path in paths:
-        if Path(path).exists():
-            shutil.rmtree(path)
+        shutil.rmtree(path)
 
 
 if not {{ cookiecutter.is_known_license }}:
@@ -29,7 +28,7 @@ if not {{ cookiecutter.include_components }}:
 if not {{ cookiecutter.include_app }}:
     remove_dirs(
         'src/{{ cookiecutter.import_name }}/app',
-        'bundles',
+        'examples/desktop',
         'examples',
     )
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -12,7 +12,8 @@ def remove_files(*paths):
 
 def remove_dirs(*paths):
     for path in paths:
-        shutil.rmtree(path)
+        if Path(path).exists():
+            shutil.rmtree(path)
 
 
 if not {{ cookiecutter.is_known_license }}:


### PR DESCRIPTION
Fix Component app creation error

The error came from trying to delete the `bundles` folder that no longer exists when creating a Component apps

Before this commit:
```
(.venv) ulysse-durand@ulyssedurand:~/git$ cookiecutter https://github.com/Kitware/trame-cookiecutter
You've downloaded /home/ulysse-durand/.cookiecutters/trame-cookiecutter before. Is it okay to delete and re-download it? [y/n] (y): y
  [1/8] project_name (Trame App): 
  [2/8] Select project_type
    1 - App
    2 - App with Components
    3 - Components
    Choose from [1/2/3] (1): 3
  [3/8] author (Trame Developer): 
  [4/8] short_description (An example Trame application): 
  [5/8] Select license
    1 - Apache Software License
    2 - BSD License
    3 - MIT License
    4 - ISC License (ISCL)
    5 - GNU General Public License v3 (GPLv3)
    6 - Other
    Choose from [1/2/3/4/5/6] (1): 2
  [6/8] include_continuous_integration (y): 
  [7/8] package_name (trame-app): 
  [8/8] import_name (trame_app): 
Traceback (most recent call last):
  File "/tmp/tmpk1n23xur.py", line 29, in <module>
    remove_dirs(
  File "/tmp/tmpk1n23xur.py", line 15, in remove_dirs
    shutil.rmtree(path)
  File "/usr/lib/python3.12/shutil.py", line 775, in rmtree
    onexc(os.lstat, path, err)
  File "/usr/lib/python3.12/shutil.py", line 773, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'bundles'
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```

After this commit the error is fixed and the project creates well